### PR TITLE
Add IN, NOT IN and IQueryCommand

### DIFF
--- a/Flepper.QueryBuilder/Commands/Extensions/QueryCommandExtensions.cs
+++ b/Flepper.QueryBuilder/Commands/Extensions/QueryCommandExtensions.cs
@@ -1,0 +1,11 @@
+﻿using System;
+namespace Flepper.QueryBuilder
+{
+    internal static class QueryCommandExtensions
+    {        
+        internal static QueryBuilder AsQueryBuilder(this Func<IQueryCommand, IQueryCommand> query)
+        {                 
+            return (QueryBuilder)query?.Invoke(new QueryBuilder());
+        }
+    }
+}

--- a/Flepper.QueryBuilder/Filters/Extensions/WhereFilterExtensions.cs
+++ b/Flepper.QueryBuilder/Filters/Extensions/WhereFilterExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Flepper.QueryBuilder
+﻿using System;
+
+namespace Flepper.QueryBuilder
 {
     /// <summary>
     /// Where Extensions
@@ -108,5 +110,41 @@
         /// <returns></returns>
         public static IComparisonOperators Between<TFrom, TTo>(this IWhereFilter whereFilter, TFrom from, TTo to)
             => whereFilter is IComparisonOperators command ? command.Between(from, to) : null;
+        
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="whereFilter"></param>
+        /// <param name="values"></param>
+        /// <returns></returns>
+        public static IComparisonOperators In(this IWhereFilter whereFilter, params object[] values)
+            => whereFilter is IComparisonOperators command ? command.In(values) : null;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="whereFilter"></param>
+        /// <param name="values"></param>
+        /// <returns></returns>
+        public static IComparisonOperators NotIn(this IWhereFilter whereFilter, params object[] values)
+            => whereFilter is IComparisonOperators command ? command.NotIn(values) : null;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="whereFilter"></param>
+        /// <param name="query"></param>
+        /// <returns></returns>
+        public static IComparisonOperators In(this IWhereFilter whereFilter, Func<IQueryCommand, IQueryCommand> query)
+            => whereFilter is IComparisonOperators command ? command.In(query) : null;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="whereFilter"></param>
+        /// <param name="query"></param>
+        /// <returns></returns>
+        public static IComparisonOperators NotIn(this IWhereFilter whereFilter, Func<IQueryCommand, IQueryCommand> query)
+            => whereFilter is IComparisonOperators command ? command.NotIn(query) : null;
     }
 }

--- a/Flepper.QueryBuilder/Operators/Comparison/Interfaces/IComparisonOperators.cs
+++ b/Flepper.QueryBuilder/Operators/Comparison/Interfaces/IComparisonOperators.cs
@@ -1,4 +1,6 @@
-﻿namespace Flepper.QueryBuilder
+﻿using System;
+
+namespace Flepper.QueryBuilder
 {
     /// <summary>
     /// Comparison Operator Interface
@@ -86,5 +88,34 @@
         /// <param name="to"></param>
         /// <returns></returns>
         IComparisonOperators Between<TFrom, TTo>(TFrom from, TTo to);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="values"></param>
+        /// <returns></returns>
+        IComparisonOperators In(params object[] values);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="values"></param>
+        /// <returns></returns>
+        IComparisonOperators NotIn(params object[] values);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="query"></param>
+        /// <returns></returns>
+        IComparisonOperators In(Func<IQueryCommand, IQueryCommand> query);
+
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="query"></param>
+        /// <returns></returns>
+        IComparisonOperators NotIn(Func<IQueryCommand, IQueryCommand> query);
     }
 }

--- a/Flepper.QueryBuilder/Operators/Logical/Extensions/LogicalOperatorsExtensions.cs
+++ b/Flepper.QueryBuilder/Operators/Logical/Extensions/LogicalOperatorsExtensions.cs
@@ -1,4 +1,6 @@
 ﻿
+using System;
+
 namespace Flepper.QueryBuilder
 {
     /// <summary>
@@ -14,6 +16,14 @@ namespace Flepper.QueryBuilder
         /// <returns></returns>
         public static IComparisonOperators EqualTo<T>(this ILogicalOperators logicalOperators, T value)
             => logicalOperators is IComparisonOperators command ? command.EqualTo(value) : null;
+
+        /// <summary>
+        /// Add Equal NULL Operator to query
+        /// </summary>
+        /// <param name="logicalOperators">Logical Operators instance</param>
+        /// <returns>Value</returns>
+        public static IComparisonOperators EqualNull(this ILogicalOperators logicalOperators)
+           => logicalOperators is IComparisonOperators command ? command.EqualNull() : null;
 
         /// <summary>
         /// Add Greater Than Operator to query
@@ -99,5 +109,41 @@ namespace Flepper.QueryBuilder
         /// <returns></returns>
         public static IComparisonOperators Between<TFrom, TTo>(this ILogicalOperators logicalOperators, TFrom from, TTo to)
             => logicalOperators is IComparisonOperators command ? command.Between(from, to) : null;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="logicalOperators"></param>
+        /// <param name="values"></param>
+        /// <returns></returns>
+        public static IComparisonOperators In(this ILogicalOperators logicalOperators, params object[] values)
+            => logicalOperators is IComparisonOperators command ? command.In(values) : null;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="logicalOperators"></param>
+        /// <param name="values"></param>
+        /// <returns></returns>
+        public static IComparisonOperators NotIn(this ILogicalOperators logicalOperators, params object[] values)
+            => logicalOperators is IComparisonOperators command ? command.NotIn(values) : null;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="logicalOperators"></param>
+        /// <param name="query"></param>
+        /// <returns></returns>
+        public static IComparisonOperators In(this ILogicalOperators logicalOperators, Func<IQueryCommand, IQueryCommand> query)
+            => logicalOperators is IComparisonOperators command ? command.In(query) : null;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="logicalOperators"></param>
+        /// <param name="query"></param>
+        /// <returns></returns>
+        public static IComparisonOperators NotIn(this ILogicalOperators logicalOperators, Func<IQueryCommand, IQueryCommand> query)
+            => logicalOperators is IComparisonOperators command ? command.NotIn(query) : null;
     }
 }

--- a/Flepper.QueryBuilder/Operators/Values/ValuesOperator.cs
+++ b/Flepper.QueryBuilder/Operators/Values/ValuesOperator.cs
@@ -12,9 +12,8 @@ namespace Flepper.QueryBuilder
         }
 
         public IValuesOperator Values(Func<IQueryCommand, IQueryCommand> query)
-        {            
-            QueryBuilder querySelect = new QueryBuilder();
-            querySelect = (QueryBuilder)query.Invoke(querySelect);
+        {
+            QueryBuilder querySelect = query.AsQueryBuilder();
             Command.Append(querySelect.Command);
             foreach (var parameter in querySelect?.Parameters)
             {

--- a/Flepper.QueryBuilder/QueryBuilder.cs
+++ b/Flepper.QueryBuilder/QueryBuilder.cs
@@ -16,7 +16,7 @@ namespace Flepper.QueryBuilder
         {
             Command = new StringBuilder();
             Parameters = new Dictionary<string, object>();
-        }
+        }        
 
         internal QueryBuilder(StringBuilder command, IDictionary<string, object> parameters, SqlColumn[] columns)
         {

--- a/Flepper.QueryBuilder/Utils/Extensions/StringBuilderExtensions.cs
+++ b/Flepper.QueryBuilder/Utils/Extensions/StringBuilderExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using System.Text;
+
+namespace Flepper.QueryBuilder.Utils.Extensions
+{
+    internal static class StringBuilderExtensions
+    {
+        public static StringBuilder Replace(this StringBuilder str, IDictionary<string, string> values)
+        {
+            if (values?.Count == 0) return str;
+            foreach (var dic in values)
+                str = str.Replace(dic.Key, dic.Value);
+            return str;
+        }
+    }
+}

--- a/Flepper.QueryBuilder/Utils/Extensions/StringExtensions.cs
+++ b/Flepper.QueryBuilder/Utils/Extensions/StringExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace Flepper.QueryBuilder.Utils.Extensions
 {
@@ -9,6 +11,6 @@ namespace Flepper.QueryBuilder.Utils.Extensions
         {
             column = strs[0];
             alias = strs[1];
-        }
+        }        
     }
 }

--- a/Flepper.Tests.Integration/QueryBuilder/InsertTests.cs
+++ b/Flepper.Tests.Integration/QueryBuilder/InsertTests.cs
@@ -98,7 +98,7 @@ namespace Flepper.Tests.Integration.QueryBuilder
                     .Execute();
 
                 rows.Should()
-                    .BeGreaterThan(0);
+                    .BeGreaterThan(0);                
             }
         }
     }

--- a/Flepper.Tests.Integration/QueryBuilder/SelectTests.cs
+++ b/Flepper.Tests.Integration/QueryBuilder/SelectTests.cs
@@ -146,6 +146,62 @@ namespace Flepper.Tests.Integration.QueryBuilder
                 profiles.Should().NotBeEmpty();
             }
         }
+
+        [Fact]
+        public void ShouldSelectUserWithWhereIn()
+        {
+            using (var connection = _databaseFixture.Connection)
+            {
+                var users = connection.Select()
+                    .From("User")
+                    .Where("Id").In(1, 2, 3)
+                    .Query();
+
+                users.Should().NotBeEmpty();
+            }
+        }
+
+        [Fact]
+        public void ShouldSelectUserWithWhereNotIn()
+        {
+            using (var connection = _databaseFixture.Connection)
+            {
+                var users = connection.Select()
+                    .From("User")
+                    .Where("Id").NotIn(1, 2, 3)
+                    .Query();
+
+                users.Should().BeNullOrEmpty();
+            }
+        }
+
+        [Fact]
+        public void ShouldSelectUserWithWhereInSelect()
+        {
+            using (var connection = _databaseFixture.Connection)
+            {
+                var users = connection.Select()
+                    .From("User")
+                    .Where("Id").In(_ => connection.Select("Id").From("Profile"))
+                    .Query();
+
+                users.Should().NotBeEmpty();
+            }
+        }
+
+        [Fact]
+        public void ShouldSelectUserWithWhereNotInSelect()
+        {
+            using (var connection = _databaseFixture.Connection)
+            {
+                var users = connection.Select()
+                    .From("User")
+                    .Where("Id").NotIn(_ => connection.Select("Id").From("Profile"))
+                    .Query();
+
+                users.Should().NotBeEmpty();
+            }
+        }
     }
 
     public class Profile

--- a/Flepper.Tests.Unit/QueryBuilder/Commands/InsertCommandTests.cs
+++ b/Flepper.Tests.Unit/QueryBuilder/Commands/InsertCommandTests.cs
@@ -184,5 +184,166 @@ namespace Flepper.Tests.Unit.QueryBuilder.Commands
             Assert.Equal(1, parameters.@p0);
         }
 
+        [Fact]
+        public void ShouldCreateInsertStatementWithSelectQueryBuilderWithWhereAndIn()
+        {
+            var querySelect = FlepperQueryBuilder
+                .Select(new string[] { "column1", "column2" })
+                .From("Test2")
+                .Where("Id").EqualTo(1)
+                .And("Status").In("A", "B");
+
+            var queryResult = FlepperQueryBuilder
+                .Insert()
+                .Into("Test")
+                .Columns(new string[] { "column1", "column2" })
+                .Values(_ => querySelect)
+                .BuildWithParameters();
+
+            Assert.Equal("INSERT INTO [Test] ([column1],[column2] ) SELECT [column1],[column2] FROM [Test2] WHERE [Id] = @p0 AND [Status] IN(@p1,@p2) ", queryResult.Query);
+
+            dynamic parameters = queryResult.Parameters;
+            Assert.Equal(1, parameters.@p0);
+            Assert.Equal("A", parameters.@p1);
+            Assert.Equal("B", parameters.@p2);
+        }
+
+        [Fact]
+        public void ShouldCreateInsertStatementWithSelectQueryBuilderWithWhereAndNotIn()
+        {
+            var querySelect = FlepperQueryBuilder
+                .Select(new string[] { "column1", "column2" })
+                .From("Test2")
+                .Where("Id").EqualTo(1)
+                .And("Status").NotIn("A", "B");
+
+            var queryResult = FlepperQueryBuilder
+                .Insert()
+                .Into("Test")
+                .Columns(new string[] { "column1", "column2" })
+                .Values(_ => querySelect)
+                .BuildWithParameters();
+
+            Assert.Equal("INSERT INTO [Test] ([column1],[column2] ) SELECT [column1],[column2] FROM [Test2] WHERE [Id] = @p0 AND [Status] NOT IN(@p1,@p2) ", queryResult.Query);
+
+            dynamic parameters = queryResult.Parameters;
+            Assert.Equal(1, parameters.@p0);
+            Assert.Equal("A", parameters.@p1);
+            Assert.Equal("B", parameters.@p2);
+        }
+
+
+        [Fact]
+        public void ShouldCreateInsertStatementWithSelectQueryBuilderWithWhereAndInSelect()
+        {
+            var querySelect = FlepperQueryBuilder
+                .Select(new string[] { "column1", "column2" })
+                .From("Test2")
+                .Where("Id").EqualTo(1)
+                .And("Status").In(_ => FlepperQueryBuilder.Select("Status").From("Test3").Where("Id").EqualTo(2));
+                
+            var queryResult = FlepperQueryBuilder
+                .Insert()
+                .Into("Test")
+                .Columns(new string[] { "column1", "column2" })
+                .Values(_ => querySelect)
+                .BuildWithParameters();
+
+            Assert.Equal("INSERT INTO [Test] ([column1],[column2] ) SELECT [column1],[column2] FROM [Test2] WHERE [Id] = @p0 AND [Status] IN(SELECT [Status] FROM [Test3] WHERE [Id] = @p1 ) ", queryResult.Query);
+
+            dynamic parameters = queryResult.Parameters;
+            Assert.Equal(1, parameters.@p0);
+            Assert.Equal(2, parameters.@p1);
+        }
+
+        [Fact]
+        public void ShouldCreateInsertStatementWithSelectQueryBuilderWithWhereAndNotInSelect()
+        {
+            var querySelect = FlepperQueryBuilder
+                .Select(new string[] { "column1", "column2" })
+                .From("Test2")
+                .Where("Id").EqualTo(1)
+                .And("Status").NotIn(_ => FlepperQueryBuilder.Select("Status").From("Test3").Where("Id").EqualTo(2));
+
+            var queryResult = FlepperQueryBuilder
+                .Insert()
+                .Into("Test")
+                .Columns(new string[] { "column1", "column2" })
+                .Values(_ => querySelect)
+                .BuildWithParameters();
+
+            Assert.Equal("INSERT INTO [Test] ([column1],[column2] ) SELECT [column1],[column2] FROM [Test2] WHERE [Id] = @p0 AND [Status] NOT IN(SELECT [Status] FROM [Test3] WHERE [Id] = @p1 ) ", queryResult.Query);
+
+            dynamic parameters = queryResult.Parameters;
+            Assert.Equal(1, parameters.@p0);
+            Assert.Equal(2, parameters.@p1);
+        }
+
+        [Fact]
+        public void ShouldCreateSelectStatementWithWhereAndInWithWhereIQueryCommand()
+        {
+            var querySelect0 = FlepperQueryBuilder.Select("Status").From("Test").Where("Id").EqualTo(100);
+            var queryResult = FlepperQueryBuilder
+                .Select()
+                .From("TestSuper")
+                .Where("Id").In(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+                .And("Id").In(_ => querySelect0) // IQueryCommand
+                .And("Id").In(11, 12, 13, 14, 15, 16, 17, 18, 19, 20)
+                .BuildWithParameters();
+
+            Assert.Equal("SELECT * FROM [TestSuper] WHERE [Id] IN(@p0,@p1,@p2,@p3,@p4,@p5,@p6,@p7,@p8,@p9) AND [Id] IN(SELECT [Status] FROM [Test] WHERE [Id] = @p10 ) AND [Id] IN(@p11,@p12,@p13,@p14,@p15,@p16,@p17,@p18,@p19,@p20) ", queryResult.Query);
+
+            dynamic parameters = queryResult.Parameters;
+            Assert.Equal(1, parameters.@p0);
+            Assert.Equal(2, parameters.@p1);
+            Assert.Equal(3, parameters.@p2);
+            Assert.Equal(4, parameters.@p3);
+            Assert.Equal(5, parameters.@p4);
+            Assert.Equal(6, parameters.@p5);
+            Assert.Equal(7, parameters.@p6);
+            Assert.Equal(8, parameters.@p7);
+            Assert.Equal(9, parameters.@p8);
+            Assert.Equal(10, parameters.@p9);
+            Assert.Equal(100, parameters.@p10);
+            Assert.Equal(11, parameters.@p11);
+            Assert.Equal(12, parameters.@p12);
+            Assert.Equal(13, parameters.@p13);
+            Assert.Equal(14, parameters.@p14);
+            Assert.Equal(15, parameters.@p15);
+            Assert.Equal(16, parameters.@p16);
+            Assert.Equal(17, parameters.@p17);
+            Assert.Equal(18, parameters.@p18);
+            Assert.Equal(19, parameters.@p19);
+            Assert.Equal(20, parameters.@p20);
+        }
+
+        [Fact]
+        public void ShouldCreateSelectStatementWithWhereAndSelectQueryBuilder()
+        {
+            var querySelect0 = FlepperQueryBuilder.Select("Status").From("Test1").Where("Id").EqualTo(10);
+            var querySelect1 = FlepperQueryBuilder.Select("Status").From("Test1").Where("Id").EqualTo(20);
+            var querySelect2 = FlepperQueryBuilder.Select("Status").From("Test1").Where("Id").EqualTo(30);
+
+            var queryResult = FlepperQueryBuilder
+                .Select()
+                .From("TestSuper")
+                .Where("Id").NotEqualTo(1)
+                .And("Status").In(_ => querySelect0)
+                .And("Id").NotEqualTo(2)
+                .And("Status").In(_ => querySelect1)
+                .And("Id").NotEqualTo(3)
+                .And("Status").In(_ => querySelect2)
+                .BuildWithParameters();
+
+            Assert.Equal("SELECT * FROM [TestSuper] WHERE [Id] <> @p0 AND [Status] IN(SELECT [Status] FROM [Test1] WHERE [Id] = @p1 ) AND [Id] <> @p2 AND [Status] IN(SELECT [Status] FROM [Test1] WHERE [Id] = @p3 ) AND [Id] <> @p4 AND [Status] IN(SELECT [Status] FROM [Test1] WHERE [Id] = @p5 ) ", queryResult.Query);
+
+            dynamic parameters = queryResult.Parameters;
+            Assert.Equal(1, parameters.@p0);
+            Assert.Equal(10, parameters.@p1);
+            Assert.Equal(2, parameters.@p2);
+            Assert.Equal(20, parameters.@p3);
+            Assert.Equal(3, parameters.@p4);
+            Assert.Equal(30, parameters.@p5);
+        }
     }
 }

--- a/Flepper.Tests.Unit/QueryBuilder/Commands/WhereFilterTests.cs
+++ b/Flepper.Tests.Unit/QueryBuilder/Commands/WhereFilterTests.cs
@@ -304,7 +304,7 @@ namespace Flepper.Tests.Unit.QueryBuilder.Commands
             result.Query
                 .Trim()
                 .Should()
-                .Be("SELECT * FROM [table] WHERE [field1] LIKE @p0  AND [field2] LIKE @p1  AND [field3] LIKE @p2");
+                .Be("SELECT * FROM [table] WHERE [field1] LIKE @p0 AND [field2] LIKE @p1 AND [field3] LIKE @p2");
 
             dynamic parameters = result.Parameters;
             Assert.Equal("%abc1%", parameters.@p0);


### PR DESCRIPTION
Add IN, NOT IN and IQueryCommand

Example

```
FlepperQueryBuilder.Select("Id", "Name", "Birthday")
	.From("User")
	.Where("Id").In(1, 2, 3)
	.BuildWithParameters();	
```
---
```
FlepperQueryBuilder.Select("Id", "Name", "Birthday")
	.From("User")
	.Where("Id").NotIn(1, 2, 3)
	.BuildWithParameters();
```
---
```
FlepperQueryBuilder.Select("Id", "Name", "Birthday")
	.From("User")
	.Where("Active").EqualTo(1)
	.And("Id")
           .In(_ => FlepperQueryBuilder.Select("Id").From("Profile").Where("Active").EqualTo(1))
	.And("Name").Contains("A")                
	.BuildWithParameters();
```